### PR TITLE
Update npx and yarn getting started commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The all-in-one starter kit for high-performance SaaS applications. With a few cl
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
 
 ```bash
-npx create-next-app --example saas-starter my-saas-app
+npx create-next-app --example https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth my-saas-app
 # or
-yarn create next-app --example saas-starter my-saas-app
+yarn create next-app --example https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth my-saas-app
 ```
 
 ## Configuration


### PR DESCRIPTION
👋 hello! I went to use this template today and the `npx` and `yarn` commands failed with the following error:

```
Could not locate an example named "saas-starter". Please check your spelling and try again.
```

I'm not sure how a template gets to use a nice name like that, but I was able to get it to work by pointing to the template directly.

Feel free to edit this PR if there's a better way to handle this. Thanks for the great template! ✨ 