### PR TITLE
chore: turn off realtime subscriptions - better for security

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,3 +1,6 @@
+-- turn off realtime subscriptions for this schema.
+drop publication if exists supabase_realtime;
+
 /** 
 * USERS
 * Note: This table contains user data. Users should only be able to view and update their own data.


### PR DESCRIPTION
@thorwebdev as discussed - this will disable realtime across the whole app

FYI - it doesn't have to be right at the top, happy to move it to the bottom 